### PR TITLE
Fix #4

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -656,8 +656,7 @@ def asyncSlot(*args):
         @Slot(*args)
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            asyncio.ensure_future(fn(*args, **kwargs))
-
+            return asyncio.ensure_future(fn(*args, **kwargs))
         return wrapper
 
     return outer_decorator


### PR DESCRIPTION
P.S. Subclassing QObjects with asyncSlots is impossible without this.