### PR TITLE
Fix issues with Qt 5.15 where QSocketNotifier.activated became overloaded

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -394,13 +394,13 @@ class _QEventLoop:
         else:
             # this is necessary to avoid race condition-like issues
             existing.setEnabled(False)
-            existing.activated.disconnect()
+            existing.activated['int'].disconnect()
             # will get overwritten by the assignment below anyways
 
         notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read)
         notifier.setEnabled(True)
         self._logger.debug('Adding reader callback for file descriptor {}'.format(fd))
-        notifier.activated.connect(
+        notifier.activated['int'].connect(
             lambda: self.__on_notifier_ready(
                 self._read_notifiers, notifier, fd, callback, args)  # noqa: C812
         )
@@ -430,13 +430,13 @@ class _QEventLoop:
         else:
             # this is necessary to avoid race condition-like issues
             existing.setEnabled(False)
-            existing.activated.disconnect()
+            existing.activated['int'].disconnect()
             # will get overwritten by the assignment below anyways
 
         notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Write)
         notifier.setEnabled(True)
         self._logger.debug('Adding writer callback for file descriptor {}'.format(fd))
-        notifier.activated.connect(
+        notifier.activated['int'].connect(
             lambda: self.__on_notifier_ready(
                 self._write_notifiers, notifier, fd, callback, args)  # noqa: C812
         )
@@ -470,7 +470,7 @@ class _QEventLoop:
             if notifiers.get(fd, None) is notifier:
                 notifier.setEnabled(True)
             else:
-                notifier.activated.disconnect()
+                notifier.activated['int'].disconnect()
 
     def __on_notifier_ready(self, notifiers, notifier, fd, callback, args):
         if fd not in notifiers:

--- a/qasync/_unix.py
+++ b/qasync/_unix.py
@@ -110,11 +110,11 @@ class _Selector(selectors.BaseSelector):
 
         if events & EVENT_READ:
             notifier = QtCore.QSocketNotifier(key.fd, QtCore.QSocketNotifier.Read)
-            notifier.activated.connect(self.__on_read_activated)
+            notifier.activated['int'].connect(self.__on_read_activated)
             self.__read_notifiers[key.fd] = notifier
         if events & EVENT_WRITE:
             notifier = QtCore.QSocketNotifier(key.fd, QtCore.QSocketNotifier.Write)
-            notifier.activated.connect(self.__on_write_activated)
+            notifier.activated['int'].connect(self.__on_write_activated)
             self.__write_notifiers[key.fd] = notifier
 
         return key
@@ -138,7 +138,7 @@ class _Selector(selectors.BaseSelector):
             except KeyError:
                 pass
             else:
-                notifier.activated.disconnect()
+                notifier.activated['int'].disconnect()
 
         try:
             key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))


### PR DESCRIPTION
After upgrading to Qt 5.15/PySide2 5.15.1 I noticed that the asyncio-Qt mainloop integration was completely broken - websockets stayed hanging in a connecting state, async HTTP requests never returned a response i.e. no callbacks were ever called.

Troubleshooting revealed that the `__on_read_activated` slots in `_unix.py` received a `PySide2.QtCore.QSocketDescriptor object`. Those were obviously not found in the `_fd_to_key` directory mapping, as the key expected there is the (int) file descriptor.

In the Qt documentation I found that the QSocketNotifier.activated behavior changed with Qt 5.15, whereas [previously](https://doc.qt.io/qt-5.14/qsocketnotifier.html#activated) only the `QSocketNotifier::activated(int socket)` signal existed, [now](https://doc.qt.io/qt-5.15/qsocketnotifier.html#activated) this signal became overloaded with `QSocketNotifier::activated(QSocketDescriptor socket, QSocketNotifier::Type type)` as arguments.

Long story short, this pull requests fixes the issue by explicitly connecting the signal with "int" soket fd as argument.