### PR TITLE
Ensure sufficient stack size for worker threads

### DIFF
--- a/tests/test_qthreadexec.py
+++ b/tests/test_qthreadexec.py
@@ -35,3 +35,15 @@ def test_ctx_after_shutdown(shutdown_executor):
 def test_submit_after_shutdown(shutdown_executor):
     with pytest.raises(RuntimeError):
         shutdown_executor.submit(None)
+
+
+def test_stack_recursion_limit(executor):
+    # Test that worker threads have sufficient stack size for the default
+    # sys.getrecursionlimit. If not this should fail with SIGSEGV or SIGBUS
+    # (or event SIGILL?)
+    def rec(a, *args, **kwargs):
+        rec(a, *args, **kwargs)
+    fs = [executor.submit(rec, 1) for _ in range(10)]
+    for f in fs:
+        with pytest.raises(RecursionError):
+            f.result()


### PR DESCRIPTION
The default worker stack size for QThreadExecutor executor on macOS is insufficient to survive the default max recursion level.

I.e. The following fails with a SIGBUS error on macOS with Python 3.7.5

```python
from qasync import QThreadExecutor

def func(a, *arg, **kwarg):
    func(a, *arg, **kwarg)

with QThreadExecutor(1) as executor:
    f = executor.submit(func, 1)
    assert isinstance(f.exception(), RecursionError)
```

Also it is impossible to use the official numpy wheel distributions with bundled openblas (https://github.com/numpy/numpy/issues/11551) due to the default stack size.


The defaults in this PR are copied from https://github.com/python/cpython/blob/v3.9.0/Python/thread_pthread.h#L35



