### PR TITLE
Use the xvfb service for xenial linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 sudo: required
 dist: xenial
+services:
+  - xvfb
 
 python:
   - "3.5"
@@ -8,10 +10,6 @@ python:
   - "3.7"
 
 cache: pip
-
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 install:
   - pip install pipenv


### PR DESCRIPTION
This PR uses the xvfb service available in travis CI for xenial linux - instead of manually finding and starting xvfb. Ref https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide#3-headless-browser-testing

See failures in Travis CI in the previous PR here - https://travis-ci.org/github/CabbageDevelopment/qasync/builds/753538279

```
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```