### PR TITLE
Catch selector remove_writer() calls in Python>=3.9

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -456,7 +456,7 @@ class _QEventLoop:
         """Get time according to event loop's clock."""
         return time.monotonic()
 
-    def add_reader(self, fd, callback, *args):
+    def _add_reader(self, fd, callback, *args):
         """Register a callback for when a file descriptor is ready for reading."""
         self._check_closed()
 
@@ -480,7 +480,7 @@ class _QEventLoop:
         )
         self._read_notifiers[fd] = notifier
 
-    def remove_reader(self, fd):
+    def _remove_reader(self, fd):
         """Remove reader callback."""
         if self.is_closed():
             return
@@ -494,7 +494,7 @@ class _QEventLoop:
             notifier.setEnabled(False)
             return True
 
-    def add_writer(self, fd, callback, *args):
+    def _add_writer(self, fd, callback, *args):
         """Register a callback for when a file descriptor is ready for writing."""
         self._check_closed()
         try:
@@ -517,7 +517,7 @@ class _QEventLoop:
         )
         self._write_notifiers[fd] = notifier
 
-    def remove_writer(self, fd):
+    def _remove_writer(self, fd):
         """Remove writer callback."""
         if self.is_closed():
             return


### PR DESCRIPTION
Fixes #28, fixes #27.

In Python 3.9, selector_events.py stopped internally using the
`add_writer()` and `remove_writer()` public class interface, instead
calling `_add_writer()` and `_remove_writer()`. This was broken upstream
in https://github.com/python/cpython/commit/3a2667d91e3

This meant the `_remove_writer()` call was never unregistering the
QSocketNotifier, as qasync does not override that method. Rather than
crash, the write callback was simply ignoring the duplicate calls,
resulting in 100% CPU.

Cope with this by overriding the internal method names instead. This
looks like it will work at least as far back as Python 3.6. The upstream
Python repository has broken tags somehow so I can't check back further.