### PR TITLE
Reduce logging overhead

### DIFF
--- a/qasync/_unix.py
+++ b/qasync/_unix.py
@@ -120,13 +120,13 @@ class _Selector(selectors.BaseSelector):
         return key
 
     def __on_read_activated(self, fd):
-        self._logger.debug('File {} ready to read'.format(fd))
+        self._logger.debug('File %s ready to read', fd)
         key = self._key_from_fd(fd)
         if key:
             self.__parent._process_event(key, EVENT_READ & key.events)
 
     def __on_write_activated(self, fd):
-        self._logger.debug('File {} ready to write'.format(fd))
+        self._logger.debug('File %s ready to write', fd)
         key = self._key_from_fd(fd)
         if key:
             self.__parent._process_event(key, EVENT_WRITE & key.events)
@@ -205,17 +205,17 @@ class _SelectorEventLoop(asyncio.SelectorEventLoop):
 
     def _process_event(self, key, mask):
         """Selector has delivered us an event."""
-        self._logger.debug('Processing event with key {} and mask {}'.format(key, mask))
+        self._logger.debug('Processing event with key %s and mask %s', key, mask)
         fileobj, (reader, writer) = key.fileobj, key.data
         if mask & selectors.EVENT_READ and reader is not None:
             if reader._cancelled:
                 self.remove_reader(fileobj)
             else:
-                self._logger.debug('Invoking reader callback: {}'.format(reader))
+                self._logger.debug('Invoking reader callback: %s', reader)
                 reader._run()
         if mask & selectors.EVENT_WRITE and writer is not None:
             if writer._cancelled:
                 self.remove_writer(fileobj)
             else:
-                self._logger.debug('Invoking writer callback: {}'.format(writer))
+                self._logger.debug('Invoking writer callback: %s', writer)
                 writer._run()

--- a/qasync/_windows.py
+++ b/qasync/_windows.py
@@ -39,7 +39,7 @@ class _ProactorEventLoop(asyncio.ProactorEventLoop):
         """Process events from proactor."""
         for f, callback, transferred, key, ov in events:
             try:
-                self._logger.debug('Invoking event callback {}'.format(callback))
+                self._logger.debug('Invoking event callback %s', callback)
                 value = callback(transferred, key, ov)
             except OSError as e:
                 self._logger.debug('Event callback failed', exc_info=sys.exc_info())
@@ -162,7 +162,7 @@ class _EventWorker(QtCore.QThread):
         while not self.__stop:
             events = self.__proactor.select(0.01)
             if events:
-                self._logger.debug('Got events from poll: {}'.format(events))
+                self._logger.debug('Got events from poll: %s', events)
                 self.__sig_events.emit(events)
 
         self._logger.debug('Exiting thread')
@@ -177,7 +177,7 @@ class _EventPoller:
         self.sig_events = sig_events
 
     def start(self, proactor):
-        self._logger.debug('Starting (proactor: {})...'.format(proactor))
+        self._logger.debug('Starting (proactor: %s)...', proactor)
         self.__worker = _EventWorker(proactor, self)
         self.__worker.start()
 


### PR DESCRIPTION
I noticed in some cases with a lot of async functions flying around, this logging overhead can become quite dramatic.
In the worst case I had a task taking 60 seconds drop to 15 after killing all the logging (as in removing the lines, not just disabling the logger).
So I've tackled this in two ways.

1. Using pythons lazy logging. So that if there is no handler picking up the debug messages, we have no string formatting overhead.
2. Tying the debug logging in the event loop to the built in "(set|get)_debug" state. So even with debug logging enabled, the messages from the event loop can selectively be enabled/disabled.
