### PR TITLE
Fix TypeError when using qasync alongside grpc

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -131,7 +131,7 @@ class _QThreadWorker(QtCore.QThread):
             future, callback, args, kwargs = command
             self._logger.debug(
                 "#%s got callback %s with args %s and kwargs %s from queue",
-                    self.__num, callback, args, kwargs
+                self.__num, callback, args, kwargs
             )
             if future.set_running_or_notify_cancel():
                 self._logger.debug("Invoking callback")
@@ -284,6 +284,16 @@ class _SimpleTimer(QtCore.QObject):
     def __log_debug(self, *args, **kwargs):
         if self.__debug_enabled:
             self._logger.debug(*args, **kwargs)
+
+
+def _fileno(fd):
+    if isinstance(fd, int):
+        return fd
+    try:
+        return int(fd.fileno())
+    except (AttributeError, TypeError, ValueError):
+        raise ValueError(f"Invalid file object: {fd!r}") from None
+
 
 @with_logger
 class _QEventLoop:
@@ -474,7 +484,7 @@ class _QEventLoop:
             existing.activated["int"].disconnect()
             # will get overwritten by the assignment below anyways
 
-        notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read)
+        notifier = QtCore.QSocketNotifier(_fileno(fd), QtCore.QSocketNotifier.Read)
         notifier.setEnabled(True)
         self.__log_debug("Adding reader callback for file descriptor %s", fd)
         notifier.activated["int"].connect(


### PR DESCRIPTION
```
    Traceback (most recent call last):
    File "/src/main.py", line 67, in on_clicked
        async with grpc.aio.insecure_channel('localhost:50051') as channel:
    File "/usr/local/lib/python3.8/dist-packages/grpc/aio/_channel.py", line 448, in insecure_channel
        return Channel(target, () if options is None else options, None,
    File "/usr/local/lib/python3.8/dist-packages/grpc/aio/_channel.py", line 277, in __init__
        self._channel = cygrpc.AioChannel(
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/channel.pyx.pxi", line 30, in grpc._cython.cygrpc.AioChannel.__cinit__
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 126, in grpc._cython.cygrpc.init_grpc_aio
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 130, in grpc._cython.cygrpc.init_grpc_aio
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/grpc_aio.pyx.pxi", line 117, in grpc._cython.cygrpc._initialize_per_loop
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi", line 95, in grpc._cython.cygrpc.PollerCompletionQueue.bind_loop
    File "src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi", line 60, in grpc._cython.cygrpc._BoundEventLoop.__cinit__
    File "/usr/lib/python3.8/asyncio/selector_events.py", line 334, in add_reader
        return self._add_reader(fd, callback, *args)
    File "/usr/local/lib/python3.8/dist-packages/qasync/__init__.py", line 477, in _add_reader
        notifier = QtCore.QSocketNotifier(fd, QtCore.QSocketNotifier.Read)
    TypeError: QSocketNotifier: first argument (socket) must be an int.
```

Fixes #37