### PR TITLE
Cleanup timers

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -281,7 +281,7 @@ class _SimpleTimer(QtCore.QObject):
 
         # Clean up old timers
         to_delete = []
-        for (key, (_, timestamp)) in self._timers:
+        for (key, (_, timestamp)) in self._timers.items():
             if datetime.utcnow() - timestamp > timedelta(seconds=60):
                 to_delete.append(key)
 

--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -251,49 +251,12 @@ def _make_signaller(qtimpl_qtcore, *args):
 class _SimpleTimer(QtCore.QObject):
     def __init__(self):
         super().__init__()
-        self.__callbacks = {}
         self._stopped = False
         self.__debug_enabled = False
 
     def add_callback(self, handle, delay=0):
         QtCore.QTimer.singleShot(int(delay * 1000), lambda: handle._run() if not handle._cancelled else None)
         return handle
-        #timerid = self.startTimer(int(delay * 1000))
-        #if delay != 0:
-        #    print(f"Non-zero delay {delay} for {timerid}")
-        #self.__log_debug("Registering timer id %s", timerid)
-        #assert timerid not in self.__callbacks
-        #self.__callbacks[timerid] = handle
-        #return handle
-
-    def timerEvent(self, event):  # noqa: N802
-        timerid = event.timerId()
-        self.__log_debug("Timer event on id %s", timerid)
-        if self._stopped:
-            self.__log_debug("Timer stopped, killing %s", timerid)
-            self.killTimer(timerid)
-            del self.__callbacks[timerid]
-        else:
-            try:
-                handle = self.__callbacks[timerid]
-            except KeyError as e:
-                print(f"No timer: {timerid}")
-                self.__log_debug(e)
-            else:
-                if handle._cancelled:
-                    self.__log_debug("Handle %s cancelled", handle)
-                else:
-                    self.__log_debug("Calling handle %s", handle)
-                    try:
-                        handle._run()
-                    except:
-                        print("WTF?!?")
-            finally:
-                if timerid in self.__callbacks:
-                    del self.__callbacks[timerid]
-                handle = None
-                self.killTimer(timerid)
-                print(f"Deleted timer {timerid}: Remaining {len(self.__callbacks)}")
 
     def stop(self):
         self.__log_debug("Stopping timers")

--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -282,9 +282,12 @@ class _SimpleTimer(QtCore.QObject):
                     self.__log_debug("Calling handle %s", handle)
                     handle._run()
             finally:
-                del self.__callbacks[timerid]
+                if timerid in self.__callbacks:
+                    del self.__callbacks[timerid]
                 handle = None
-            self.killTimer(timerid)
+                print(f"Timers: {len(self.__callbacks)}")
+
+                self.killTimer(timerid)
 
     def stop(self):
         self.__log_debug("Stopping timers")

--- a/qasync/_windows.py
+++ b/qasync/_windows.py
@@ -87,13 +87,16 @@ class _IocpProactor(windows_events.IocpProactor):
         """Override in order to handle events in a threadsafe manner."""
         if timeout is None:
             ms = UINT32_MAX  # wait for eternity
+            print("Bug?")
         elif timeout < 0:
+            print("Bug?")
             raise ValueError("negative timeout")
         else:
             # GetQueuedCompletionStatus() has a resolution of 1 millisecond,
             # round away from zero to wait *at least* timeout seconds.
             ms = math.ceil(timeout * 1e3)
             if ms >= UINT32_MAX:
+                print("Bug?")
                 raise ValueError("timeout too big")
 
         with QtCore.QMutexLocker(self._lock):

--- a/qasync/_windows.py
+++ b/qasync/_windows.py
@@ -87,16 +87,13 @@ class _IocpProactor(windows_events.IocpProactor):
         """Override in order to handle events in a threadsafe manner."""
         if timeout is None:
             ms = UINT32_MAX  # wait for eternity
-            print("Bug?")
         elif timeout < 0:
-            print("Bug?")
             raise ValueError("negative timeout")
         else:
             # GetQueuedCompletionStatus() has a resolution of 1 millisecond,
             # round away from zero to wait *at least* timeout seconds.
             ms = math.ceil(timeout * 1e3)
             if ms >= UINT32_MAX:
-                print("Bug?")
                 raise ValueError("timeout too big")
 
         with QtCore.QMutexLocker(self._lock):


### PR DESCRIPTION
This merge request resolves #35.

There are issues with both the timer created by `startTimer` and `QTimer.oneshot`.  Both of these functions seem to behave identically on my test environment, and both create the issues documented in #35.

To resolve these issues, I create a pool of `QTimer` objects, and have the timers stop themselves after each run.  I create one `QTimer` for each unique value of "delay".  In addition, I delete old timers that have not been used for more than 60 seconds.

Rather than associating each handle with a unique timer, I associate a list of handles with the timer matching the `delay` value, and execute all associated functions in sequence.  This should be compatible with all async guarantees, by my understanding.

This should mean that the number of timers created is always equal or lower than `startTimer` or QTimer.oneshot`.  In practice, the number of timers created is much lower.

I am concerned about threading, as I'm not sure what the threading guarantees are on the modified object.  As a result, I wrote this assuming a single-threaded application.  If threading support is needed, then at minimum `self.handles` must be locked.

This patch has been tested on both Windows and Linux.