### PR TITLE
Custom QApplication  Error

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -796,7 +796,7 @@ def asyncSlot(*args):
 
 class QEventLoopPolicyMixin:
     def new_event_loop(self):
-        return QEventLoop(QApplication(sys.argv))
+        return QEventLoop(QApplication.instance() or QApplication(sys.argv))
 
 
 class DefaultQEventLoopPolicy(


### PR DESCRIPTION
If I use a custom QApplication, the program is running incorrectly

```

class QSingleApplication(QApplication):
    ...


async def main(app: QSingleApplication):
    def close_future(future, loop: qasync.QIOCPEventLoop):
        if loop.is_running():
            future.set_result(True)

    loop = asyncio.get_event_loop()
    future = asyncio.Future()
    app.aboutToQuit.connect(functools.partial(close_future, future, loop))

    mainWindow = QMainWindow()
    mainWindow.show()

    return await future


if __name__ == '__main__':
    try:
        app = QSingleApplication()
        qasync.run(main(app))
    except Exception as err:
        print(f'Exception:{err=}')
        sys.exit(0)

```

**Error**
```
RuntimeError('Please destroy the QSingleApplication singleton before creating a new QApplication instance.')

```
