### PR TITLE
Allow asyncSlot slots to accept signals with mismatched signatures

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -374,6 +374,7 @@ class _QEventLoop:
 
         try:
             self.__log_debug("Starting Qt event loop")
+            asyncio.events._set_running_loop(self)
             rslt = -1
             try:
                 rslt = self.__app.exec_()
@@ -382,6 +383,7 @@ class _QEventLoop:
             self.__log_debug("Qt event loop ended with result %s", rslt)
             return rslt
         finally:
+            asyncio.events._set_running_loop(None)
             self._after_run_forever()
             self.__is_running = False
 

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -221,6 +221,27 @@ def test_loop_not_running(loop):
     assert not loop.is_running()
 
 
+def test_get_running_loop_fails_after_completion(loop):
+    """Verify that after loop stops, asyncio.get_running_loop() correctly raises a RuntimeError."""
+    async def is_running_loop():
+        nonlocal loop
+        assert asyncio.get_running_loop() == loop
+
+    loop.run_until_complete(is_running_loop())
+    with pytest.raises(RuntimeError):
+        assert asyncio.get_running_loop() != loop
+
+
+def test_loop_can_run_twice(loop):
+    """Verify that loop is correctly reset as asyncio.get_running_loop() when restarted."""
+    async def is_running_loop():
+        nonlocal loop
+        assert asyncio.get_running_loop() == loop
+
+    loop.run_until_complete(is_running_loop())
+    loop.run_until_complete(is_running_loop())
+
+
 def test_can_function_as_context_manager(application):
     """Verify that a QEventLoop can function as its own context manager."""
     with qasync.QEventLoop(application) as loop:


### PR DESCRIPTION
Qt ignores trailing args from a signal but python does not so inspect the slot signature and if it's not callable try removing args until it is.

In the test case below without the patch the error I get is:

```
Traceback (most recent call last):
  File "/home/david/venv-heating-jan23/lib/python3.9/site-packages/qasync/__init__.py", line 789, in wrapper
    task = asyncio.ensure_future(fn(*args, **kwargs))
TypeError: myaslot() takes 1 positional argument but 2 were given
```

I'm not sure if this is the best way to solve the problem as I don't think the slot code is handled in python in Pyside.

I don't have a Pyside6 environment to test with.

```[python3]
#!/usr/bin/env python3
import asyncio
import sys

import qasync

from PySide2.QtCore import QObject, QCoreApplication, QTimer, Signal, Slot


class myclass(QObject):

    def __init__(self, parent=None):
        QObject.__init__(self, parent)
        self.timer = QTimer()
        self.timer.setSingleShot(True)
        self.timer.timeout.connect(self.myslot)
        self.timer.start(2000)
        self.mysignal_with_arg.connect(self.myaslot)
        self.mysignal_without_arg.connect(self.myaslot)

    mysignal_with_arg = Signal(int)
    mysignal_without_arg = Signal()

    @qasync.asyncSlot()
    async def myaslot(self):
        print("myaslot")

    @Slot()
    def myslot(self):
        print("myslot")
        self.mysignal_without_arg.emit()
        self.mysignal_with_arg.emit(23)

async def main(app):
    print("In main")
    instance = myclass()
    await asyncio.sleep(10)
    app.quit()

if __name__ == "__main__":
    app = QCoreApplication(sys.argv)
    loop = qasync.QEventLoop(app)
    asyncio.set_event_loop(loop)
    loop.create_task(main(app))
    loop.run_forever()
```