### PR TITLE
Fix running loop

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -373,6 +373,7 @@ class _QEventLoop:
 
         try:
             self.__log_debug("Starting Qt event loop")
+            asyncio.events._set_running_loop(self)
             rslt = -1
             try:
                 rslt = self.__app.exec_()
@@ -381,6 +382,7 @@ class _QEventLoop:
             self.__log_debug("Qt event loop ended with result %s", rslt)
             return rslt
         finally:
+            asyncio.events._set_running_loop(None)
             self._after_run_forever()
             self.__is_running = False
 

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -221,6 +221,27 @@ def test_loop_not_running(loop):
     assert not loop.is_running()
 
 
+def test_get_running_loop_fails_after_completion(loop):
+    """Verify that after loop stops, asyncio.get_running_loop() correctly raises a RuntimeError."""
+    async def is_running_loop():
+        nonlocal loop
+        assert asyncio.get_running_loop() == loop
+
+    loop.run_until_complete(is_running_loop())
+    with pytest.raises(RuntimeError):
+        assert asyncio.get_running_loop() != loop
+
+
+def test_loop_can_run_twice(loop):
+    """Verify that loop is correctly reset as asyncio.get_running_loop() when restarted."""
+    async def is_running_loop():
+        nonlocal loop
+        assert asyncio.get_running_loop() == loop
+
+    loop.run_until_complete(is_running_loop())
+    loop.run_until_complete(is_running_loop())
+
+
 def test_can_function_as_context_manager(application):
     """Verify that a QEventLoop can function as its own context manager."""
     with qasync.QEventLoop(application) as loop:


### PR DESCRIPTION
When using pytest and pytest-asyncio and pytest-django it became clear that although the loop was stopping and starting between tests, asyncio.get_running_loop() was not detecting this and this caused Django some issues with mis-detecting async running during fixture setup.

This will probably also help with issue #72

