### PR TITLE
Fix test workflow, pinned to ubuntu-20.04 instead of latest.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,7 @@ jobs:
         exclude:
           - os: windows-latest
             python: "3.6"
-            qt:
-              - package: PyQt6
+            qt: { package: PyQt6, qt_api: "pyqt6" }
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           pipenv run --python ${{ matrix.python }} pip install ${{ matrix.qt.package }} pytest
 
       - name: Install Libxcb dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         python: ["3.6", "3.7", "3.8", "3.9"]
         qt:
           - package: PyQt5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,11 @@ jobs:
             qt_api: "pyside2"
           - package: PySide6
             qt_api: "pyside6"
-        # exclude:
-        #   - {os: windows-latest, qt: {package: PySide2}}
+        exclude:
+          - os: windows-latest
+            python: "3.6"
+            qt:
+              - package: PyQt6
 
     steps:
       - name: Checkout
@@ -49,7 +52,7 @@ jobs:
           sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
 
       - name: Run headless test
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: coactions/setup-xvfb@v1
         env:
           QT_API: ${{ matrix.qt.qt_api }}
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Black formats the Python code.
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qasync
 
-[![Maintenance](https://img.shields.io/maintenance/yes/2022)](https://pypi.org/project/qasync)
+[![Maintenance](https://img.shields.io/maintenance/yes/2023)](https://pypi.org/project/qasync)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qasync)](https://pypi.org/project/qasync)
 [![PyPI - License](https://img.shields.io/pypi/l/qasync)](/LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/qasync)](https://pypi.org/project/qasync)

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -222,21 +222,22 @@ def test_loop_not_running(loop):
 
 
 def test_get_running_loop_fails_after_completion(loop):
-    """Verify that after loop stops, asyncio.get_running_loop() correctly raises a RuntimeError."""
+    """Verify that after loop stops, asyncio._get_running_loop() correctly returns None."""
+
     async def is_running_loop():
         nonlocal loop
-        assert asyncio.get_running_loop() == loop
+        assert asyncio._get_running_loop() == loop
 
     loop.run_until_complete(is_running_loop())
-    with pytest.raises(RuntimeError):
-        assert asyncio.get_running_loop() != loop
+    assert asyncio._get_running_loop() is None
 
 
 def test_loop_can_run_twice(loop):
-    """Verify that loop is correctly reset as asyncio.get_running_loop() when restarted."""
+    """Verify that loop is correctly reset as asyncio._get_running_loop() when restarted."""
+
     async def is_running_loop():
         nonlocal loop
-        assert asyncio.get_running_loop() == loop
+        assert asyncio._get_running_loop() == loop
 
     loop.run_until_complete(is_running_loop())
     loop.run_until_complete(is_running_loop())


### PR DESCRIPTION
- Python 3.6 is not available in ubuntu-latest (22.04 LTS)
- Fix tests that required `asyncio.get_running_loop()` which is not available in python 3.6
- Switched to `coactions/setup-xvfb@v1` from deprecacted `GabrielBB/xvfb-action@v1.6`
- Exclude matrix for python3.6, windows-latest, pyqt6 as it is attempting to build Qt from source
- Explicit black version for pre-commit checks