### PR TITLE
Avoid running app.exec() inside except block

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -376,9 +376,9 @@ class _QEventLoop:
             self.__log_debug("Starting Qt event loop")
             asyncio.events._set_running_loop(self)
             rslt = -1
-            try:
+            if hasattr(self.__app, 'exec_'):
                 rslt = self.__app.exec_()
-            except AttributeError:
+            else:
                 rslt = self.__app.exec()
             self.__log_debug("Qt event loop ended with result %s", rslt)
             return rslt


### PR DESCRIPTION
Use hasattr() to determine how to run the app instead of a try/except-clause. Without this change, exceptions inside the app always begin with a confusing error from the try-block in qasync:
![image](https://github.com/VegarS/qasync/assets/1231463/a5c29597-a54c-48f9-a849-99f8acb53722)
