### PR TITLE
Fix qasync.run in Python 3.11

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -330,9 +330,11 @@ class _QEventLoop:
     If the event loop shall be used with an existing and already running QApplication
     it must be specified in the constructor via already_running=True
     In this case the user is responsible for loop cleanup with stop() and close()
+
+    The set_running_loop parameter is there for backwards compatibility and does nothing.
     """
 
-    def __init__(self, app=None, set_running_loop=True, already_running=False):
+    def __init__(self, app=None, set_running_loop=False, already_running=False):
         self.__app = app or QApplication.instance()
         assert self.__app is not None, "No QApplication has been instantiated"
         self.__is_running = False
@@ -350,9 +352,6 @@ class _QEventLoop:
         assert self.__app is not None
         super().__init__()
 
-        if set_running_loop:
-            asyncio.events._set_running_loop(self)
-
         # We have to set __is_running to True after calling
         # super().__init__() because of a bug in BaseEventLoop.
         if already_running:
@@ -362,6 +361,9 @@ class _QEventLoop:
             # postprocessing for the eventloop is done
             self._before_run_forever()
             self.__app.aboutToQuit.connect(self._after_run_forever)
+
+            # for asyncio to recognize the already running loop
+            asyncio.events._set_running_loop(self)
 
     def run_forever(self):
         """Run eventloop forever."""


### PR DESCRIPTION
`QEventLoop`s previously set themselves as the running loop by default on construction, regardless of if they are actually running or not. For `already_running` loops, this is fine, but for non-`already_running` loops, this setting of the running loop is premature.

This is because `asyncio` may check for an existing running loop after it constructs a new `QEventLoop`, but before running it. If it does, it will falsely detect the newly constructed, never ran loop as the "running" loop.

This didn't happen until Python 3.11, where `asyncio.run` checks for a running loop both before and after getting a new `QEventLoop` with the use of the new `asyncio.Runner.run`, hence raising a `RuntimeError`.

Set `QEventLoop`s as the running loop on construction exclusively when they are already running. This means the set_running_loop constructor parameter is now unused, but for backwards compatibility I've left it intact (as [existing code](https://github.com/CabbageDevelopment/qasync/issues/72#issue-1534755831) already referred to this parameter by keyword).

The [original commit that put it there](https://github.com/CabbageDevelopment/qasync/commit/5a2f75b85e296a6237a2be386ddd5b15ff93f1b4) was, from what I can tell, in response to a `RuntimeError` raised when calling `asyncio.sleep` because of [Python 3.8 switching to using get_running_loop in asyncio.sleep in place of get_event_loop](https://github.com/python/cpython/commit/558c49bcf3a8543d64a68de836b5d855efd56696). For non-`already_running` loops, since the fix in #75, this is redundant, as QEventLoop.run_forever sets the running loop.

Fixes #68.