### PR TITLE
Improve examples and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ if __name__ == "__main__":
 
     event_loop = QEventLoop(app)
     asyncio.set_event_loop(event_loop)
+
     app_close_event = asyncio.Event()
     app.aboutToQuit.connect(app_close_event.set)
-
 
     main_window = MainWindow()
     main_window.show()

--- a/README.md
+++ b/README.md
@@ -11,21 +11,27 @@
 
 `qasync` allows coroutines to be used in PyQt/PySide applications by providing an implementation of the `PEP 3156` event-loop.
 
-With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread` or `QThread`. Single-threaded concurrency does not inherently make the app slower, but only safer, because of Python's GIL. The concept of single-threaded app is also adopted by Flutter and JavaScript due to its benefits.
+With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. The concept of single-threaded app is also adopted by Flutter and JavaScript due to its benefits. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread` or `QThread`. Single-threaded concurrency does not inherently make the app slower, but only safer, because of Python's GIL.
 
 If you need some CPU-intensive tasks to be executed in parallel, `qasync` also got that covered, providing `QEventLoop.run_in_executor` which is basically identical to that of `asyncio`.
 
 ### Basic Example
 
 ```python
+from qasync import QEventLoop, asyncClose, asyncSlot
+
+
 class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
 
-        self.setLayout(QVBoxLayout())
+    @asyncClose
+    async def closeEvent(self, event):  # noqa:N802
+        pass
 
-        self.lbl_status = QLabel("Idle", self)
-        self.layout().addWidget(self.lbl_status)
+    @asyncSlot()
+    async def on_my_event(self):
+        pass
 
 
 if __name__ == "__main__":
@@ -33,14 +39,14 @@ if __name__ == "__main__":
 
     event_loop = QEventLoop(app)
     asyncio.set_event_loop(event_loop)
-    app_close_event = asyncio.Event()
 
+    app_close_event = asyncio.Event()
     app.aboutToQuit.connect(app_close_event.set)
+
     main_window = MainWindow()
     main_window.show()
 
-    event_loop.create_task(main_window.boot())
-    event_loop.run_until_complete(asyncio.wait_for(app_close_event.wait(), None))
+    event_loop.run_until_complete(app_close_event.wait())
     event_loop.close()
 ```
 
@@ -54,7 +60,10 @@ More detailed examples can be found [here](https://github.com/CabbageDevelopment
 
 ## Requirements
 
-`qasync` requires Python >= 3.8, and PyQt5/PyQt6 or PySide2/PySide6. The library is tested on Ubuntu, Windows and MacOS.
+- Python >= 3.8
+- PyQt5/PyQt6 or PySide2/PySide6
+
+`qasync` is tested on Ubuntu, Windows and MacOS.
 
 If you need Python 3.6 or 3.7 support, use the [v0.25.0](https://github.com/CabbageDevelopment/qasync/releases/tag/v0.25.0) tag/release.
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,20 @@
 
 ## Introduction
 
-`qasync` allows coroutines to be used in PyQt/PySide applications by providing an implementation of the `PEP 3156` event-loop.
+`qasync` allows coroutines to be used in PyQt/PySide applications by providing an implementation of the `PEP 3156` event loop.
 
-With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. The concept of single-threaded app is also adopted by Flutter and JavaScript due to its benefits. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread` or `QThread`. Single-threaded concurrency does not inherently make the app slower, but only safer, because of Python's GIL.
+With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread` or `QThread`.
 
-If you need some CPU-intensive tasks to be executed in parallel, `qasync` also got that covered, providing `QEventLoop.run_in_executor` which is basically identical to that of `asyncio`.
+If you need some CPU-intensive tasks to be executed in parallel, `qasync` also got that covered, providing `QEventLoop.run_in_executor` which is functionally identical to that of `asyncio`.
 
 ### Basic Example
 
 ```python
-from qasync import QEventLoop, asyncClose, asyncSlot
+import sys
+import asyncio
 
+from qasync import QEventLoop, QApplication
+from PySide6.QtWidgets import QWidget, QVBoxLayout
 
 class MainWindow(QWidget):
     def __init__(self):
@@ -39,15 +42,15 @@ if __name__ == "__main__":
 
     event_loop = QEventLoop(app)
     asyncio.set_event_loop(event_loop)
-
     app_close_event = asyncio.Event()
     app.aboutToQuit.connect(app_close_event.set)
+
 
     main_window = MainWindow()
     main_window.show()
 
-    event_loop.run_until_complete(app_close_event.wait())
-    event_loop.close()
+    with event_loop:
+        event_loop.run_until_complete(app_close_event.wait())
 ```
 
 More detailed examples can be found [here](https://github.com/CabbageDevelopment/qasync/tree/master/examples).

--- a/README.md
+++ b/README.md
@@ -11,11 +11,44 @@
 
 `qasync` allows coroutines to be used in PyQt/PySide applications by providing an implementation of the `PEP 3156` event-loop.
 
-`qasync` is a fork of [asyncqt](https://github.com/gmarull/asyncqt), which is a fork of [quamash](https://github.com/harvimt/quamash). May it live longer than its predecessors.
+With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread`, `QThread`, etc. Because of Python's GIL, making your app single-threaded does not inherently make it slower, but only safer.
 
-#### The future of `qasync`
+If you need some CPU-intensive tasks to be executed in parallel, `qasync` also got that covered, providing `QEventLoop.run_in_executor` which is basically identical to that of `asyncio`.
 
-`qasync` was created because `asyncqt` and `quamash` are no longer maintained.
+### Basic Example
+
+```python
+class MainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+
+        self.setLayout(QVBoxLayout())
+
+        self.lbl_status = QLabel("Idle", self)
+        self.layout().addWidget(self.lbl_status)
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    event_loop = QEventLoop(app)
+    asyncio.set_event_loop(event_loop)
+    app_close_event = asyncio.Event()
+
+    app.aboutToQuit.connect(app_close_event.set)
+    main_window = MainWindow()
+    main_window.show()
+
+    event_loop.create_task(main_window.boot())
+    event_loop.run_until_complete(asyncio.wait_for(app_close_event.wait(), None))
+    event_loop.close()
+```
+
+More detailed examples can be found [here](https://github.com/CabbageDevelopment/qasync/tree/master/examples).
+
+### The future of `qasync`
+
+`qasync` is a fork of [asyncqt](https://github.com/gmarull/asyncqt), which is a fork of [quamash](https://github.com/harvimt/quamash). `qasync` was created because those are no longer maintained. May it live longer than its predecessors.
 
 **`qasync` will continue to be maintained, and will still be accepting pull requests.**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 `qasync` allows coroutines to be used in PyQt/PySide applications by providing an implementation of the `PEP 3156` event-loop.
 
-With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread`, `QThread`, etc. Because of Python's GIL, making your app single-threaded does not inherently make it slower, but only safer.
+With `qasync`, you can use `asyncio` functionalities directly inside Qt app's event loop, in the main thread. Using async functions for Python tasks can be much easier and cleaner than using `threading.Thread` or `QThread`. Single-threaded concurrency does not inherently make the app slower, but only safer, because of Python's GIL. The concept of single-threaded app is also adopted by Flutter and JavaScript due to its benefits.
 
 If you need some CPU-intensive tasks to be executed in parallel, `qasync` also got that covered, providing `QEventLoop.run_in_executor` which is basically identical to that of `asyncio`.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ if __name__ == "__main__":
 
 More detailed examples can be found [here](https://github.com/CabbageDevelopment/qasync/tree/master/examples).
 
-### The future of `qasync`
+### The Future of `qasync`
 
 `qasync` is a fork of [asyncqt](https://github.com/gmarull/asyncqt), which is a fork of [quamash](https://github.com/harvimt/quamash). `qasync` was created because those are no longer maintained. May it live longer than its predecessors.
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
 
+        self.setLayout(QVBoxLayout())
+        self.lbl_status = QLabel("Idle", self)
+        self.layout().addWidget(self.lbl_status)
+
     @asyncClose
-    async def closeEvent(self, event):  # noqa:N802
+    async def closeEvent(self, event):
         pass
 
     @asyncSlot()
-    async def on_my_event(self):
+    async def onMyEvent(self):
         pass
 
 

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -72,14 +72,10 @@ if __name__ == "__main__":
     asyncio.set_event_loop(event_loop)
     app_close_event = asyncio.Event()
 
+    app.aboutToQuit.connect(app_close_event.set)
     main_window = MainWindow()
     main_window.show()
 
-    async def keep_app_lifecycle():
-        await app_close_event.wait()
-
-    app.aboutToQuit.connect(app_close_event.set)
-
     event_loop.create_task(main_window.boot())
-    event_loop.run_until_complete(keep_app_lifecycle())
+    event_loop.run_until_complete(asyncio.wait_for(app_close_event.wait(), None))
     event_loop.close()

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -40,11 +40,14 @@ class MainWindow(QWidget):
         self.btn_fetch.clicked.connect(self.on_btn_fetch_clicked)
         self.layout().addWidget(self.btn_fetch)
 
-        self.session = aiohttp.ClientSession()
+        self.session: aiohttp.ClientSession
 
     @asyncClose
     async def closeEvent(self, event):  # noqa:N802
         await self.session.close()
+
+    async def boot(self):
+        self.session = aiohttp.ClientSession()
 
     @asyncSlot()
     async def on_btn_fetch_clicked(self):
@@ -80,5 +83,6 @@ if __name__ == "__main__":
 
     app.aboutToQuit.connect(close_app)
 
+    event_loop.create_task(main_window.boot())
     event_loop.run_until_complete(keep_app_lifecycle())
     event_loop.close()

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -22,9 +22,6 @@ class MainWindow(QWidget):
     _DEF_URL = "https://jsonplaceholder.typicode.com/todos/1"
     """str: Default URL."""
 
-    _SESSION_TIMEOUT = 1.0
-    """float: Session timeout."""
-
     def __init__(self):
         super().__init__()
 

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -27,18 +27,18 @@ class MainWindow(QWidget):
 
         self.setLayout(QVBoxLayout())
 
-        self.lblStatus = QLabel("Idle", self)
-        self.layout().addWidget(self.lblStatus)
+        self.lbl_status = QLabel("Idle", self)
+        self.layout().addWidget(self.lbl_status)
 
-        self.editUrl = QLineEdit(self._DEF_URL, self)
-        self.layout().addWidget(self.editUrl)
+        self.edit_url = QLineEdit(self._DEF_URL, self)
+        self.layout().addWidget(self.edit_url)
 
-        self.editResponse = QTextEdit("", self)
-        self.layout().addWidget(self.editResponse)
+        self.edit_response = QTextEdit("", self)
+        self.layout().addWidget(self.edit_response)
 
-        self.btnFetch = QPushButton("Fetch", self)
-        self.btnFetch.clicked.connect(self.on_btnFetch_clicked)
-        self.layout().addWidget(self.btnFetch)
+        self.btn_fetch = QPushButton("Fetch", self)
+        self.btn_fetch.clicked.connect(self.on_btn_fetch_clicked)
+        self.layout().addWidget(self.btn_fetch)
 
         self.session = aiohttp.ClientSession()
 
@@ -47,19 +47,19 @@ class MainWindow(QWidget):
         await self.session.close()
 
     @asyncSlot()
-    async def on_btnFetch_clicked(self):  # noqa:N802
-        self.btnFetch.setEnabled(False)
-        self.lblStatus.setText("Fetching...")
+    async def on_btn_fetch_clicked(self):
+        self.btn_fetch.setEnabled(False)
+        self.lbl_status.setText("Fetching...")
 
         try:
-            async with self.session.get(self.editUrl.text()) as r:
-                self.editResponse.setText(await r.text())
+            async with self.session.get(self.edit_url.text()) as r:
+                self.edit_response.setText(await r.text())
         except Exception as exc:
-            self.lblStatus.setText("Error: {}".format(exc))
+            self.lbl_status.setText("Error: {}".format(exc))
         else:
-            self.lblStatus.setText("Finished!")
+            self.lbl_status.setText("Finished!")
         finally:
-            self.btnFetch.setEnabled(True)
+            self.btn_fetch.setEnabled(True)
 
 
 if __name__ == "__main__":

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -75,13 +75,10 @@ if __name__ == "__main__":
     main_window = MainWindow()
     main_window.show()
 
-    def close_app():
-        app_close_event.set()
-
     async def keep_app_lifecycle():
         await app_close_event.wait()
 
-    app.aboutToQuit.connect(close_app)
+    app.aboutToQuit.connect(app_close_event.set)
 
     event_loop.create_task(main_window.boot())
     event_loop.run_until_complete(keep_app_lifecycle())

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -19,8 +19,8 @@ from qasync import QEventLoop, asyncClose, asyncSlot
 class MainWindow(QWidget):
     """Main window."""
 
-    _DEF_URL = "https://jsonplaceholder.typicode.com/todos/1"
-    """str: Default URL."""
+    _DEF_URL: str = "https://jsonplaceholder.typicode.com/todos/1"
+    """Default URL."""
 
     def __init__(self):
         super().__init__()

--- a/examples/aiohttp_fetch.py
+++ b/examples/aiohttp_fetch.py
@@ -70,12 +70,13 @@ if __name__ == "__main__":
 
     event_loop = QEventLoop(app)
     asyncio.set_event_loop(event_loop)
-    app_close_event = asyncio.Event()
 
+    app_close_event = asyncio.Event()
     app.aboutToQuit.connect(app_close_event.set)
+    
     main_window = MainWindow()
     main_window.show()
 
     event_loop.create_task(main_window.boot())
-    event_loop.run_until_complete(asyncio.wait_for(app_close_event.wait(), None))
+    event_loop.run_until_complete(app_close_event.wait())
     event_loop.close()

--- a/examples/executor_example.py
+++ b/examples/executor_example.py
@@ -33,7 +33,9 @@ def last_50(progress, loop):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
+
     event_loop = QEventLoop(app)
     asyncio.set_event_loop(event_loop)
+
     event_loop.run_until_complete(master())
     event_loop.close()

--- a/examples/executor_example.py
+++ b/examples/executor_example.py
@@ -1,11 +1,10 @@
 import functools
-import sys
 import asyncio
 import time
-import qasync
+import sys
 
-# from PyQt5.QtWidgets import (
-from PySide2.QtWidgets import QApplication, QProgressBar
+# from PyQt6.QtWidgets import (
+from PySide6.QtWidgets import QApplication, QProgressBar
 from qasync import QEventLoop, QThreadExecutor
 
 
@@ -32,4 +31,9 @@ def last_50(progress, loop):
         time.sleep(0.1)
 
 
-qasync.run(master())
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    event_loop = QEventLoop(app)
+    asyncio.set_event_loop(event_loop)
+    event_loop.run_until_complete(master())
+    event_loop.close()

--- a/examples/executor_example.py
+++ b/examples/executor_example.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 import sys
 
-# from PyQt6.QtWidgets import (
+# from PyQt6.QtWidgets import
 from PySide6.QtWidgets import QApplication, QProgressBar
 from qasync import QEventLoop, QThreadExecutor
 

--- a/examples/qml_httpx/app.py
+++ b/examples/qml_httpx/app.py
@@ -1,0 +1,41 @@
+import sys
+import asyncio
+from pathlib import Path
+
+from qasync import QEventLoop, QApplication
+from PySide6.QtCore import QUrl
+from PySide6.QtQml import QQmlApplicationEngine, qmlRegisterType
+
+from service import ExampleService
+
+QML_PATH = Path(__file__).parent.absolute().joinpath("qml")
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    engine = QQmlApplicationEngine()
+    engine.addImportPath(QML_PATH)
+
+    app.aboutToQuit.connect(engine.deleteLater)
+    engine.quit.connect(app.quit)
+
+    # register our service, making it usable directly in QML
+    qmlRegisterType(ExampleService, "qasync", 1, 0, ExampleService.__name__)
+
+    # alternatively, instantiate the service and inject it into the QML engine
+    # service = ExampleService()
+    # engine.rootContext().setContextProperty("service", service)
+
+    event_loop = QEventLoop(app)
+    asyncio.set_event_loop(event_loop)
+
+    app_close_event = asyncio.Event()
+    app.aboutToQuit.connect(app_close_event.set)
+    engine.quit.connect(app_close_event.set)
+
+    qml_entry = QUrl.fromLocalFile(str(QML_PATH.joinpath("Main.qml")))
+    engine.load(qml_entry)
+
+    with event_loop:
+        event_loop.run_until_complete(app_close_event.wait())

--- a/examples/qml_httpx/qml/Main.qml
+++ b/examples/qml_httpx/qml/Main.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
+
+ApplicationWindow {
+    id: root
+    title: "qasync"
+    visible: true
+    width: 420
+    height: 240
+
+    Loader {
+        id: mainLoader
+        anchors.fill: parent
+        source: "Page.qml"
+    }
+}

--- a/examples/qml_httpx/qml/Page.qml
+++ b/examples/qml_httpx/qml/Page.qml
@@ -1,0 +1,65 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Controls.Material 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    ExampleService {
+        id: service
+
+        // handle value changes inside the service object
+        onValueChanged: {
+            // use value
+        }
+    }
+
+    Connections {
+        target: service
+
+        // handle value changes with an external Connection
+        function onValueChanged(value) {
+            // use value
+        }
+    }
+
+    ColumnLayout {
+        anchors {
+            fill: parent
+            margins: 10
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Button {
+                id: button
+                Layout.preferredWidth: 100
+                enabled: !service.isLoading
+
+                text: {
+                    return service.isLoading ? qsTr("Loading...") : qsTr("Fetch")
+                }
+                onClicked: function() {
+                    service.fetch(url.text)
+                }
+            }
+
+            TextField {
+                id: url
+                Layout.fillWidth: true
+                enabled: !service.isLoading
+                text: qsTr("https://jsonplaceholder.typicode.com/todos/1")
+            }
+        }
+
+        TextEdit {
+            id: text
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            // react to value changes from other widgets
+            text: service.value
+        }
+    }
+
+}

--- a/examples/qml_httpx/service.py
+++ b/examples/qml_httpx/service.py
@@ -1,0 +1,44 @@
+import httpx
+
+from qasync import asyncSlot
+from PySide6.QtCore import QObject, Signal, Property, Slot
+
+
+class ExampleService(QObject):
+    valueChanged = Signal(str, arguments=["value"])
+    loadingChanged = Signal(bool, arguments=["loading"])
+
+    def __init__(self, parent=None):
+        QObject.__init__(self, parent)
+
+        self._value = None
+        self._loading = False
+
+    def _set_value(self, value):
+        if self._value != value:
+            self._value = value
+            self.valueChanged.emit(value)
+
+    def _set_loading(self, value):
+        if self._loading != value:
+            self._loading = value
+            self.loadingChanged.emit(value)
+
+    @Property(str, notify=valueChanged)
+    def value(self) -> str:
+        return self._value
+
+    @Property(bool, notify=loadingChanged)
+    def isLoading(self) -> bool:
+        return self._loading
+
+    @asyncSlot(str)
+    async def fetch(self, endpoint: str):
+        if not endpoint:
+            return
+
+        self._set_loading(True)
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(endpoint)
+            self._set_value(resp.text)
+            self._set_loading(False)

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -591,8 +591,8 @@ def test_regression_bug13(loop, sock_pair):
 
         loop._add_reader(c_sock.fileno(), cb1)
 
-    _clent_task = asyncio.ensure_future(client_coro())
-    _server_task = asyncio.ensure_future(server_coro())
+    asyncio.ensure_future(client_coro())
+    asyncio.ensure_future(server_coro())
 
     both_done = asyncio.gather(client_done, server_done)
     loop.run_until_complete(asyncio.wait_for(both_done, timeout=1.0))

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -591,8 +591,8 @@ def test_regression_bug13(loop, sock_pair):
 
         loop._add_reader(c_sock.fileno(), cb1)
 
-    asyncio.ensure_future(client_coro())
-    asyncio.ensure_future(server_coro())
+    _client_task = asyncio.ensure_future(client_coro())
+    _server_task = asyncio.ensure_future(server_coro())
 
     both_done = asyncio.gather(client_done, server_done)
     loop.run_until_complete(asyncio.wait_for(both_done, timeout=1.0))

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -151,6 +151,8 @@ def test_can_read_subprocess(loop):
             'print("Hello async world!")',
             stdout=subprocess.PIPE,
         )
+        if process.stdout is None:
+            raise Exception("Output from the process is none")
         received_stdout = await process.stdout.readexactly(len(b"Hello async world!\n"))
         await process.wait()
         assert process.returncode == 0
@@ -589,8 +591,8 @@ def test_regression_bug13(loop, sock_pair):
 
         loop._add_reader(c_sock.fileno(), cb1)
 
-    clent_task = asyncio.ensure_future(client_coro())
-    server_task = asyncio.ensure_future(server_coro())
+    _clent_task = asyncio.ensure_future(client_coro())
+    _server_task = asyncio.ensure_future(server_coro())
 
     both_done = asyncio.gather(client_done, server_done)
     loop.run_until_complete(asyncio.wait_for(both_done, timeout=1.0))
@@ -797,4 +799,5 @@ def teardown_module(module):
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])
         for handler in handlers:
-            logger.removeHandler(handler)
+            if not isinstance(logger, logging.PlaceHolder):
+                logger.removeHandler(handler)

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -799,5 +799,5 @@ def teardown_module(module):
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])
         for handler in handlers:
-            if not isinstance(logger, logging.PlaceHolder):
+            if isinstance(logger, logging.Logger):
                 logger.removeHandler(handler)


### PR DESCRIPTION
This PR improves the example from various aspects.

- Organize imports and variable names with the Ruff formatter.
- Fix `aiohttp.ClientSession()` error saying that it should be run in an async function.
- Upgrade to `PySide6` and `PyQt6`.
- Use `asyncio.Event` instead of `CancelledError` exception to close the app gracefully.
- Use `PySide6.QApplication`. This is important because this class allows various font, theme, behavior setup. With `QApplication.instance`, app customization is not possible.
- Remove unnecessary details

And of course, I confirmed that this code works properly.