### PR TITLE
Ensure execution order of callbacks that are expected to be called immediately (such as call_soon)

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -28,6 +28,7 @@ import sys
 import time
 from concurrent.futures import Future
 from queue import Queue
+from collections import deque
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +295,58 @@ class _SimpleTimer(QtCore.QObject):
             self._logger.debug(*args, **kwargs)
 
 
+@with_logger
+class _CallSoonQueue(QtCore.QObject):
+    def __init__(self):
+        super().__init__()
+        # Contains asyncio.Handle objects
+        # Use a deque instead of Queue, as we don't require
+        # synchronization between threads here.
+        self.__callbacks = deque()
+        # Set a 0-delay timer on itself, this will ensure that
+        # timerEvent gets fired each time after window events are processed
+        # See https://doc.qt.io/qt-6/qtimer.html#interval-prop
+        self.__timerId = self.startTimer(0)
+        self.__stopped = False
+        self.__debug_enabled = False
+
+    def add_callback(self, handle):
+        # handle must be an asyncio.Handle
+        self.__callbacks.append(handle)
+        self.__log_debug("Registering call_soon handle %s", id(handle))
+        return handle
+
+    def timerEvent(self, event):
+        timerId = event.timerId()
+        assert timerId == self.__timerId
+
+        # Stop timer if stopped
+        if self.__stopped:
+            self.killTimer(timerId)
+            self.__log_debug("call_soon queue stopped, clearing handles")
+            # TODO: Do we need to del the handles or somehow invalidate them?
+            self.__callbacks.clear()
+            return
+
+        # Iterate over pending callbacks
+        # TODO: Runtime deadline, don't process the entire queue if it takes too long?
+        while len(self.__callbacks) > 0:
+            handle = self.__callbacks.popleft()
+            self.__log_debug("Calling call_soon handle %s", id(handle))
+            handle._run()
+
+    def stop(self):
+        self.__log_debug("Stopping call_soon queue")
+        self.__stopped = True
+
+    def set_debug(self, enabled):
+        self.__debug_enabled = enabled
+
+    def __log_debug(self, *args, **kwargs):
+        if self.__debug_enabled:
+            self._logger.debug(*args, **kwargs)
+
+
 def _fileno(fd):
     if isinstance(fd, int):
         return fd
@@ -339,6 +392,7 @@ class _QEventLoop:
         self._read_notifiers = {}
         self._write_notifiers = {}
         self._timer = _SimpleTimer()
+        self._call_soon_queue = _CallSoonQueue()
 
         self.__call_soon_signaller = signaller = _make_signaller(QtCore, object, tuple)
         self.__call_soon_signal = signaller.signal
@@ -441,6 +495,7 @@ class _QEventLoop:
         super().close()
 
         self._timer.stop()
+        self._call_soon_queue.stop()
         self.__app = None
 
         for notifier in itertools.chain(
@@ -474,6 +529,11 @@ class _QEventLoop:
         return self._add_callback(asyncio.Handle(callback, args, self), delay)
 
     def _add_callback(self, handle, delay=0):
+        if delay == 0:
+            # To ensure that we can guarantee the execution order of
+            # 0-delay callbacks, add them to a special queue, rather than
+            # assume that Qt will fire the timerEvents in order
+            return self._call_soon_queue.add_callback(handle)
         return self._timer.add_callback(handle, delay)
 
     def call_soon(self, callback, *args, context=None):
@@ -717,6 +777,7 @@ class _QEventLoop:
         super().set_debug(enabled)
         self.__debug_enabled = enabled
         self._timer.set_debug(enabled)
+        self._call_soon_queue.set_debug(enabled)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
### Summary

Ensure execution order of callbacks with zero delay (such as call_soon) by handling them independently of delayed callbacks.

It's reasonable to assume that custom event loops would adhere to the contract established in the `asyncio` docs. Quoting the [asyncio docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon):

> Callbacks are called in the order in which they are registered.

This PR accomplishes it by running a separate timer (with 0 timeout) for servicing immediate callbacks. According to Qt documentation, this timer will run each time the Qt event loop finishes servicing window events (https://doc.qt.io/qt-6/qtimer.html#interval-prop), which should ensure responsive operation.

Issue was observed on Windows.

I hope someone more versed in asyncio and Qt can chime in here. I see this fix more as a best-guess workaround, as I didn't dive into why the 0-delay timer callbacks would get executed out-of-order in the first place. Some quick research didn't give clear clues on whether we can expect any execution order guarantees from the original method in the first place.

### Some background

Under heavy UI load (such as real-time plotting with pyqtgraph), it was observed that the zero-delay timers scheduled via _SimpleTimer would occasionally run out-of-order on Windows. In these cases multiple immediate callbacks would be serviced within a single event loop iteration.

Unfortunately I haven't been able to get a minimum reproducible example working despite my best efforts to artificially abuse the event loop, but I'll give some overview on how the issue was observed.

We have an application that reads a realtime data stream from a BLE device (using Bleak). New values may be received up to 400 times per second, with each update causing Bleak to use `call_soon` to queue the processing of the value.

As observed, each update roughly goes through these stages:
1. Bleak calls `call_soon_threadsafe`, which makes Qt emit the passed callback as a signal
2. The signal callback calls `call_soon` (from a different thread than Bleak used)
3. qasync redirects `call_soon` to `call_later` with `delay=0`
4. `call_later` builds an `asyncio.Handle` and passes it to `_add_callback`
5. `_add_callback` redirects to the `_SimpleTimer`, which registers a timer with a timeout of 0
6. A short while later, the registered timer timeouts, and is handled by the `timerEvent` method

The out-of-order issue was observed by adding tracing to each respective stage, where the 6th stage would occasionally call the callbacks out of order, like so: [1, 2, 3, 4, 6, 5, 7, 8, ...]. No callbacks were lost.

This would only happen when the app has heavy load, such as when a graph update took longer than several milliseconds.

After applying the workaround from this PR, the issue no longer happens.