### PR TITLE
Ignore CancelledError in async slots

### DIFF
--- a/qasync/__init__.py
+++ b/qasync/__init__.py
@@ -801,6 +801,8 @@ def asyncSlot(*args, **kwargs):
             task.result()
         except Exception:
             sys.excepthook(*sys.exc_info())
+        except asyncio.CancelledError:
+            pass
 
     def outer_decorator(fn):
         @Slot(*args, **kwargs)


### PR DESCRIPTION
Normally asyncio ignored CancelledError exceptions in Tasks.  asyncSlots create tasks, but the way that the error handler is implemented, by invoking the Future.result(), this CancelledError is re-raised and then logged by the QT core.
This PR silences CancelledErrors, such as can occur on the end of application or when cancelling long running operations.