### PR TITLE
New `asyncWrap` helper to execute blocking calls on the native Qt event loop

### DIFF
--- a/examples/modal_example.py
+++ b/examples/modal_example.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+
+# from PyQt6.QtWidgets import
+from PySide6.QtWidgets import QApplication, QProgressBar, QMessageBox
+from qasync import QEventLoop, call_sync
+
+
+async def master():
+    progress = QProgressBar()
+    progress.setRange(0, 99)
+    progress.show()
+    await first_50(progress)
+    
+
+async def first_50(progress):
+    for i in range(50):
+        progress.setValue(i)
+        await asyncio.sleep(0.1)
+    
+    # Schedule the last 50% to run asynchronously
+    asyncio.create_task(
+        last_50(progress)
+    )
+    
+    # create a notification box, use helper to make entering event loop safe.
+    result = await call_sync(
+        lambda: QMessageBox.information(
+            None, "Task Completed", "The first 50% of the task is completed."
+        )
+    )
+    assert result == QMessageBox.StandardButton.Ok
+
+
+async def last_50(progress):
+    for i in range(50, 100):
+        progress.setValue(i)
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+
+    event_loop = QEventLoop(app)
+    asyncio.set_event_loop(event_loop)
+
+    event_loop.run_until_complete(master())
+    event_loop.close()

--- a/examples/modal_example.py
+++ b/examples/modal_example.py
@@ -2,8 +2,9 @@ import asyncio
 import sys
 
 # from PyQt6.QtWidgets import
-from PySide6.QtWidgets import QApplication, QProgressBar, QMessageBox
-from qasync import QEventLoop, call_sync
+from PySide6.QtWidgets import QApplication, QMessageBox, QProgressBar
+
+from qasync import QEventLoop, asyncWrap
 
 
 async def master():
@@ -11,20 +12,18 @@ async def master():
     progress.setRange(0, 99)
     progress.show()
     await first_50(progress)
-    
+
 
 async def first_50(progress):
     for i in range(50):
         progress.setValue(i)
         await asyncio.sleep(0.1)
-    
+
     # Schedule the last 50% to run asynchronously
-    asyncio.create_task(
-        last_50(progress)
-    )
-    
+    asyncio.create_task(last_50(progress))
+
     # create a notification box, use helper to make entering event loop safe.
-    result = await call_sync(
+    result = await asyncWrap(
         lambda: QMessageBox.information(
             None, "Task Completed", "The first 50% of the task is completed."
         )

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -791,12 +791,21 @@ def test_not_running_immediately_after_stopped(loop):
     loop.run_until_complete(mycoro())
     assert not loop.is_running()
 
-def test_task_recursion_fails(loop, application):
-    """Re-entering the event loop from a Task will fail if there is another
-    runnable task."""
+
+@pytest.mark.parametrize(
+    "async_wrap, expect_async_called, expect_exception",
+    [(False, False, True), (True, True, False)],
+)
+def test_async_wrap(
+    loop, application, async_wrap, expect_async_called, expect_exception
+):
+    """
+    Re-entering the event loop from a Task will fail if there is another
+    runnable task.
+    """
     async_called = False
     main_called = False
-    
+
     async def async_job():
         nonlocal async_called
         async_called = True
@@ -805,59 +814,31 @@ def test_task_recursion_fails(loop, application):
         asyncio.create_task(async_job())
         assert not async_called
         application.processEvents()
-        assert not async_called
+        assert async_called if expect_async_called else not async_called
         return 1
 
     async def main():
         nonlocal main_called
-        res = sync_callback()
+        if async_wrap:
+            res = await qasync.asyncWrap(sync_callback)
+        else:
+            res = sync_callback()
         assert res == 1
         main_called = True
 
-    exceptions= []
+    exceptions = []
     loop.set_exception_handler(lambda loop, context: exceptions.append(context))
 
     loop.run_until_complete(main())
     assert main_called, "The main function should have been called"
-    
-    # We will now have an error in there, because the task 'async_job' could not 
-    # be entered, because the task 'main' was still being executed by the event loop.
-    assert len(exceptions) == 1
-    assert isinstance(exceptions[0]["exception"], RuntimeError)
 
-
-def test_call_sync(loop, application):
-    """Re-entering the event loop from a Task will fail if there is another
-    runnable task."""
-    async_called = False
-    main_called = False
-    
-    async def async_job():
-        nonlocal async_called
-        async_called = True
-
-    def sync_callback():
-        asyncio.create_task(async_job())
-        assert not async_called
-        application.processEvents()
-        assert async_called
-        return 1
-
-    async def main():
-        nonlocal main_called
-        res = await qasync.call_sync(sync_callback)
-        assert res == 1
-        main_called = True
-
-    exceptions= []
-    loop.set_exception_handler(lambda loop, context: exceptions.append(context))
-
-    loop.run_until_complete(main())
-    assert main_called, "The main function should have been called"
-    
-    # We will now have an error in there, because the task 'async_job' could not 
-    # be entered, because the task 'main' was still being executed by the event loop.
-    assert len(exceptions) == 0
+    if expect_exception:
+        # We will now have an error in there, because the task 'async_job' could not
+        # be entered, because the task 'main' was still being executed by the event loop.
+        assert len(exceptions) == 1
+        assert isinstance(exceptions[0]["exception"], RuntimeError)
+    else:
+        assert len(exceptions) == 0
 
 
 def test_slow_callback_duration_logging(loop, caplog):

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -792,6 +792,23 @@ def test_not_running_immediately_after_stopped(loop):
     assert not loop.is_running()
 
 
+def test_call_sync(loop):
+    """Verify that call_sync works as expected."""
+    called = False
+
+    def sync_callback():
+        nonlocal called
+        called = True
+        return 1
+
+    async def main():
+        res = await qasync.call_sync(sync_callback)
+        assert res == 1
+        
+    loop.run_until_complete(main())
+    assert called, "The sync callback should have been called"
+
+
 def test_slow_callback_duration_logging(loop, caplog):
     async def mycoro():
         time.sleep(1)


### PR DESCRIPTION
This pr introduces a helper, `call_sync`, to call a synchronous method via the Qt event loop.
This is useful to use from asynchronous methods, for example to invoke modal dialogue boxes via the `.exec()` method.

If this is invoked directly from an async method, it can cause task re-entrancy in the asyncio scheduler.

By using `call_sync`, the re-entrant event loop call is done from the event loop itself with no actually running task in the scheduler.

the name `call_sync` is just a suggestion, happy to change it.

If this is not a good addition, then at least we could have a similar **example** to show how to achieve this.

