### PR TITLE
Test run_forever and run_until_complete return values

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,15 @@
-# © 2018 Gerard Marull-Paretas <gerard@teslabs.com>
-# © 2014 Mark Harviston <mark.harviston@gmail.com>
-# © 2014 Arve Knudsen <arve.knudsen@gmail.com>
-# BSD License
+"""
+Copyright (c) 2018 Gerard Marull-Paretas <gerard@teslabs.com>
+Copyright (c) 2014 Mark Harviston <mark.harviston@gmail.com>
+Copyright (c) 2014 Arve Knudsen <arve.knudsen@gmail.com>
 
-import os
+BSD License
+"""
+
 import logging
-from pytest import fixture
+import os
 
+from pytest import fixture
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(levelname)s\t%(filename)s:%(lineno)s %(message)s"


### PR DESCRIPTION
Even though asyncio `run_forever()` returns `None`, historically, since quamash qasync returns QApplication exit code. This adds a test for that, as well as testing `run_until_complete()` returning future result as per asyncio docs.