### PR TITLE
Add a QThreadPoolExecutor which uses a QThreadPool object

### DIFF
--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -320,8 +320,8 @@ class QThreadPoolExecutor(QThreadExecutorBase):
         if wait:
             for w in list(self.futures):
                 try:
-                    w.wait()
-                except CancelledError:
+                    w.result()
+                except Exception:
                     pass
 
 

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -8,7 +8,14 @@ Copyright (c) 2014 Arve Knudsen <arve.knudsen@gmail.com>
 BSD License
 """
 
-__all__ = ["QEventLoop", "QThreadExecutor", "QThreadPoolExecutor", "asyncSlot", "asyncClose", "asyncWrap"]
+__all__ = [
+    "QEventLoop",
+    "QThreadExecutor",
+    "QThreadPoolExecutor",
+    "asyncSlot",
+    "asyncClose",
+    "asyncWrap",
+]
 
 from ast import Not
 import asyncio
@@ -179,7 +186,7 @@ class QThreadExecutorBase:
         futures = list(map(lambda *args: self.submit(func, *args), *iterables))
         for future in futures:
             if timeout is not None:
-                yield future.result(timeout=time.monotonic()-start)
+                yield future.result(timeout=time.monotonic() - start)
             else:
                 yield future.result()
 


### PR DESCRIPTION
It can be useful, when using `loop.run_in_scheduler()`, to simply use the pre-existing pool of QThread objects.  a global instance of QThreadPool exists in the application, and so this is typically faster than creating a QThreadExecutor instance.

- A new QThreadPoolExecutor class is created.  It can take a QThreadPool object as the underlying pool or use the global thread pool otherwise.
- A QThreadExecutorBase class becomes the parent of both QThreadExecutor and QThreadPoolExecutor.
- add the required `map()` method, using the underlying `submit()`.
- Update signature of the `shutdown()` method, supporting the `cancel_futures` argument.
- Add various unit tests.