### PR TITLE
Use threading.Lock instead of QMutex to workaround QMutexLocker bug in PyQt6

### DIFF
--- a/src/qasync/_windows.py
+++ b/src/qasync/_windows.py
@@ -10,6 +10,7 @@ BSD License
 
 import asyncio
 import sys
+import threading
 
 try:
     import _overlapped
@@ -63,7 +64,7 @@ class _IocpProactor(windows_events.IocpProactor):
     def __init__(self):
         self.__events = []
         super(_IocpProactor, self).__init__()
-        self._lock = QtCore.QMutex()
+        self._lock = threading.Lock()
 
     def select(self, timeout=None):
         """Override in order to handle events in a threadsafe manner."""
@@ -81,50 +82,50 @@ class _IocpProactor(windows_events.IocpProactor):
     # in the order they appear in the base class source code.
 
     def recv(self, conn, nbytes, flags=0):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).recv(conn, nbytes, flags)
 
     def recv_into(self, conn, buf, flags=0):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).recv_into(conn, buf, flags)
 
     def recvfrom(self, conn, nbytes, flags=0):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).recvfrom(conn, nbytes, flags)
 
     def recvfrom_into(self, conn, buf, flags=0):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).recvfrom_into(conn, buf, flags)
 
     def sendto(self, conn, buf, flags=0, addr=None):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).sendto(conn, buf, flags, addr)
 
     def send(self, conn, buf, flags=0):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).send(conn, buf, flags)
 
     def accept(self, listener):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).accept(listener)
 
     def connect(self, conn, address):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).connect(conn, address)
 
     def sendfile(self, sock, file, offset, count):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).sendfile(sock, file, offset, count)
 
     def accept_pipe(self, pipe):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self).accept_pipe(pipe)
 
     # connect_pipe() does not actually use the delayed completion machinery.
 
     # This takes care of wait_for_handle() too.
     def _wait_for_handle(self, handle, timeout, _is_cancel):
-        with QtCore.QMutexLocker(self._lock):
+        with self._lock:
             return super(_IocpProactor, self)._wait_for_handle(
                 handle, timeout, _is_cancel
             )
@@ -148,7 +149,7 @@ class _IocpProactor(windows_events.IocpProactor):
                 break
             ms = 0
 
-            with QtCore.QMutexLocker(self._lock):
+            with self._lock:
                 err, transferred, key, address = status
                 try:
                     f, ov, obj, callback = self._cache.pop(address)


### PR DESCRIPTION
This solves https://github.com/CabbageDevelopment/qasync/issues/128