### PR TITLE
Allow asyncSlot to decorate top level functions, outside of a QObject

### DIFF
--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -824,8 +824,7 @@ def asyncSlot(*args, **kwargs):
             # Qt ignores trailing args from a signal but python does
             # not so inspect the slot signature and if it's not
             # callable try removing args until it is.
-            task = None
-            while len(args):
+            while True:
                 try:
                     inspect.signature(fn).bind(*args, **kwargs)
                 except TypeError:
@@ -834,15 +833,14 @@ def asyncSlot(*args, **kwargs):
                         args = list(args)
                         args.pop()
                         continue
+                    else:
+                        raise TypeError(
+                            "asyncSlot was not callable from Signal. Potential signature mismatch."
+                        )
                 else:
                     task = asyncio.ensure_future(fn(*args, **kwargs))
                     task.add_done_callback(_error_handler)
-                    break
-            if task is None:
-                raise TypeError(
-                    "asyncSlot was not callable from Signal. Potential signature mismatch."
-                )
-            return task
+                    return task
 
         return wrapper
 


### PR DESCRIPTION
Also added asyncSlot tests using the private `_make_signaller` to make signals. Hopefully works on all backends.

Fixes #147 