### PR TITLE
Robustify pyside

### DIFF
--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -391,6 +391,9 @@ class _QEventLoop:
             # for asyncio to recognize the already running loop
             asyncio.events._set_running_loop(self)
 
+    def get_app(self):
+        return self.__app
+
     def run_forever(self):
         """Run eventloop forever."""
 

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -476,8 +476,11 @@ class _QEventLoop:
 
         self.__log_debug("Closing event loop...")
         # Catch exceptions for safety between bindings.
-        poller = getattr(self, "_ProactorEventLoop__event_poller", None)
-        if poller is not None:
+        try:
+            poller = self.get_proactor_event_poller()
+        except AttributeError:
+            pass
+        else:
             poller.stop()
 
         if self.__default_executor is not None:

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -537,6 +537,7 @@ class _QEventLoop:
             # this is necessary to avoid race condition-like issues
             existing.setEnabled(False)
             existing.activated["int"].disconnect()
+            existing.deleteLater()
             # will get overwritten by the assignment below anyways
 
         notifier = QtCore.QSocketNotifier(
@@ -564,6 +565,7 @@ class _QEventLoop:
         else:
             notifier.setEnabled(False)
             notifier.activated["int"].disconnect()
+            notifier.deleteLater()
             return True
 
     def _add_writer(self, fd, callback, *args):
@@ -577,6 +579,7 @@ class _QEventLoop:
             # this is necessary to avoid race condition-like issues
             existing.setEnabled(False)
             existing.activated["int"].disconnect()
+            existing.deleteLater()
             # will get overwritten by the assignment below anyways
 
         notifier = QtCore.QSocketNotifier(
@@ -606,6 +609,7 @@ class _QEventLoop:
         else:
             notifier.setEnabled(False)
             notifier.activated["int"].disconnect()
+            notifier.deleteLater()
             return True
 
     def __notifier_cb_wrapper(self, notifiers, notifier, fd, callback, args):
@@ -632,6 +636,7 @@ class _QEventLoop:
             )
             notifier.setEnabled(False)
             notifier.activated["int"].disconnect()
+            notifier.deleteLater()
             return
 
         # It can be necessary to disable QSocketNotifier when e.g. checking

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -384,7 +384,9 @@ class _QEventLoop:
             self.qtparent is not None
             and self.qtparent.thread() is not QtCore.QThread.currentThread()
         ):
-            raise RuntimeError("qt_parent must belong to the same QThread as the event loop")
+            raise RuntimeError(
+                "qt_parent must belong to the same QThread as the event loop"
+            )
         self._timer.setParent(self.qtparent)
         signaller.setParent(self.qtparent)
 
@@ -499,20 +501,20 @@ class _QEventLoop:
         # Disconnect thread-safe signaller and schedule deletion of helper QObjects
         try:
             self.__call_soon_signal.disconnect()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
         try:
             # may raise if already deleted
             self.__call_soon_signaller.deleteLater()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
 
         # Stop timers first to avoid late invocations during teardown
         self._timer.stop()
         try:
             self._timer.deleteLater()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
 
         # Disable and disconnect any remaining notifiers before closing
         for notifier in itertools.chain(
@@ -683,12 +685,12 @@ class _QEventLoop:
         notifier.setEnabled(False)
         try:
             notifier.activated["int"].disconnect()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
         try:
             notifier.deleteLater()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
 
     # Methods for interacting with threads.
 

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -539,11 +539,13 @@ class _QEventLoop:
             existing.activated["int"].disconnect()
             # will get overwritten by the assignment below anyways
 
-        notifier = QtCore.QSocketNotifier(_fileno(fd), QtCore.QSocketNotifier.Type.Read)
+        notifier = QtCore.QSocketNotifier(
+            _fileno(fd), QtCore.QSocketNotifier.Type.Read, self.__app
+        )
         notifier.setEnabled(True)
         self.__log_debug("Adding reader callback for file descriptor %s", fd)
         notifier.activated["int"].connect(
-            lambda: self.__on_notifier_ready(
+            lambda *_: self.__on_notifier_ready(
                 self._read_notifiers, notifier, fd, callback, args
             )  # noqa: C812
         )
@@ -580,11 +582,12 @@ class _QEventLoop:
         notifier = QtCore.QSocketNotifier(
             _fileno(fd),
             QtCore.QSocketNotifier.Type.Write,
+            self.__app,
         )
         notifier.setEnabled(True)
         self.__log_debug("Adding writer callback for file descriptor %s", fd)
         notifier.activated["int"].connect(
-            lambda: self.__on_notifier_ready(
+            lambda *_: self.__on_notifier_ready(
                 self._write_notifiers, notifier, fd, callback, args
             )  # noqa: C812
         )

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -366,6 +366,10 @@ class _QEventLoop:
         self._timer = _SimpleTimer()
 
         self.__call_soon_signaller = signaller = _make_signaller(QtCore, object, tuple)
+        # Parent helper QObjects to the application for safe lifetime management
+        self._timer.setParent(self.__app)
+        signaller.setParent(self.__app)
+
         self.__call_soon_signal = signaller.signal
         self.__call_soon_signal.connect(
             lambda callback, args: self.call_soon(callback, *args)

--- a/src/qasync/_unix.py
+++ b/src/qasync/_unix.py
@@ -124,14 +124,9 @@ class _Selector(selectors.BaseSelector):
             try:
                 notifier = notifiers.pop(key.fd)
             except KeyError:
-                pass
+                pass  # pragma: no cover
             else:
-                notifier.setEnabled(False)
-                try:
-                    notifier.activated["int"].disconnect()
-                except Exception:
-                    pass
-                notifier.deleteLater()
+                self._delete_notifier(notifier)
 
         try:
             key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))
@@ -163,12 +158,7 @@ class _Selector(selectors.BaseSelector):
         for notifier in itertools.chain(
             self.__read_notifiers.values(), self.__write_notifiers.values()
         ):
-            notifier.setEnabled(False)
-            try:
-                notifier.activated["int"].disconnect()
-            except Exception:
-                pass
-            notifier.deleteLater()
+            self._delete_notifier(notifier)
         self.__read_notifiers.clear()
         self.__write_notifiers.clear()
 
@@ -190,6 +180,15 @@ class _Selector(selectors.BaseSelector):
             return self._fd_to_key[fd]
         except KeyError:
             return None
+
+    @staticmethod
+    def _delete_notifier(notifier):
+        notifier.setEnabled(False)
+        try:
+            notifier.activated["int"].disconnect()
+        except Exception:
+            pass  # pragma: no cover
+        notifier.deleteLater()
 
 
 class _SelectorEventLoop(asyncio.SelectorEventLoop):

--- a/src/qasync/_unix.py
+++ b/src/qasync/_unix.py
@@ -10,12 +10,16 @@ BSD License
 
 import asyncio
 import collections
+import itertools
 import selectors
 
 from . import QtCore, _fileno, with_logger
 
 EVENT_READ = 1 << 0
 EVENT_WRITE = 1 << 1
+
+# Qt5/Qt6 compatibility
+NotifierEnum = getattr(QtCore.QSocketNotifier, "Type", QtCore.QSocketNotifier)
 
 
 class _SelectorMapping(collections.abc.Mapping):
@@ -40,7 +44,7 @@ class _SelectorMapping(collections.abc.Mapping):
 
 @with_logger
 class _Selector(selectors.BaseSelector):
-    def __init__(self, parent):
+    def __init__(self, parent, qtparent=None):
         # this maps file descriptors to keys
         self._fd_to_key = {}
         # read-only mapping returned by get_map()
@@ -48,6 +52,7 @@ class _Selector(selectors.BaseSelector):
         self.__read_notifiers = {}
         self.__write_notifiers = {}
         self.__parent = parent
+        self.__qtparent = qtparent
 
     def select(self, *args, **kwargs):
         """Implement abstract method even though we don't need it."""
@@ -86,11 +91,17 @@ class _Selector(selectors.BaseSelector):
         self._fd_to_key[key.fd] = key
 
         if events & EVENT_READ:
-            notifier = QtCore.QSocketNotifier(key.fd, QtCore.QSocketNotifier.Read)
+            notifier = QtCore.QSocketNotifier(
+                key.fd, NotifierEnum.Read, self.__qtparent
+            )
+            notifier.setEnabled(True)
             notifier.activated["int"].connect(self.__on_read_activated)
             self.__read_notifiers[key.fd] = notifier
         if events & EVENT_WRITE:
-            notifier = QtCore.QSocketNotifier(key.fd, QtCore.QSocketNotifier.Write)
+            notifier = QtCore.QSocketNotifier(
+                key.fd, NotifierEnum.Write, self.__qtparent
+            )
+            notifier.setEnabled(True)
             notifier.activated["int"].connect(self.__on_write_activated)
             self.__write_notifiers[key.fd] = notifier
 
@@ -115,7 +126,12 @@ class _Selector(selectors.BaseSelector):
             except KeyError:
                 pass
             else:
-                notifier.activated["int"].disconnect()
+                notifier.setEnabled(False)
+                try:
+                    notifier.activated["int"].disconnect()
+                except Exception:
+                    pass
+                notifier.deleteLater()
 
         try:
             key = self._fd_to_key.pop(self._fileobj_lookup(fileobj))
@@ -144,6 +160,15 @@ class _Selector(selectors.BaseSelector):
     def close(self):
         self._logger.debug("Closing")
         self._fd_to_key.clear()
+        for notifier in itertools.chain(
+            self.__read_notifiers.values(), self.__write_notifiers.values()
+        ):
+            notifier.setEnabled(False)
+            try:
+                notifier.activated["int"].disconnect()
+            except Exception:
+                pass
+            notifier.deleteLater()
         self.__read_notifiers.clear()
         self.__write_notifiers.clear()
 
@@ -171,8 +196,16 @@ class _SelectorEventLoop(asyncio.SelectorEventLoop):
     def __init__(self):
         self._signal_safe_callbacks = []
 
-        selector = _Selector(self)
-        asyncio.SelectorEventLoop.__init__(self, selector)
+        try:
+            app = self.get_app()
+        except AttributeError:
+            app = None  # pragma: no cover
+        self._qtselector = _Selector(self, qtparent=app)
+        asyncio.SelectorEventLoop.__init__(self, self._qtselector)
+
+    def close(self):
+        self._qtselector.close()
+        super().close()
 
     def _before_run_forever(self):
         pass

--- a/src/qasync/_unix.py
+++ b/src/qasync/_unix.py
@@ -123,8 +123,8 @@ class _Selector(selectors.BaseSelector):
         def drop_notifier(notifiers):
             try:
                 notifier = notifiers.pop(key.fd)
-            except KeyError:
-                pass  # pragma: no cover
+            except KeyError:  # pragma: no cover
+                pass
             else:
                 self._delete_notifier(notifier)
 
@@ -186,12 +186,12 @@ class _Selector(selectors.BaseSelector):
         notifier.setEnabled(False)
         try:
             notifier.activated["int"].disconnect()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
         try:
             notifier.deleteLater()
-        except Exception:
-            pass  # pragma: no cover
+        except Exception:  # pragma: no cover
+            pass
 
 
 class _SelectorEventLoop(asyncio.SelectorEventLoop):
@@ -200,8 +200,8 @@ class _SelectorEventLoop(asyncio.SelectorEventLoop):
 
         try:
             qtparent = self.get_qtparent()
-        except AttributeError:
-            qtparent = None  # pragma: no cover
+        except AttributeError:  # pragma: no cover
+            qtparent = None
         self._qtselector = _Selector(self, qtparent=qtparent)
         asyncio.SelectorEventLoop.__init__(self, self._qtselector)
 

--- a/src/qasync/_unix.py
+++ b/src/qasync/_unix.py
@@ -188,7 +188,10 @@ class _Selector(selectors.BaseSelector):
             notifier.activated["int"].disconnect()
         except Exception:
             pass  # pragma: no cover
-        notifier.deleteLater()
+        try:
+            notifier.deleteLater()
+        except Exception:
+            pass  # pragma: no cover
 
 
 class _SelectorEventLoop(asyncio.SelectorEventLoop):
@@ -196,10 +199,10 @@ class _SelectorEventLoop(asyncio.SelectorEventLoop):
         self._signal_safe_callbacks = []
 
         try:
-            app = self.get_app()
+            qtparent = self.get_qtparent()
         except AttributeError:
-            app = None  # pragma: no cover
-        self._qtselector = _Selector(self, qtparent=app)
+            qtparent = None  # pragma: no cover
+        self._qtselector = _Selector(self, qtparent=qtparent)
         asyncio.SelectorEventLoop.__init__(self, self._qtselector)
 
     def close(self):

--- a/src/qasync/_windows.py
+++ b/src/qasync/_windows.py
@@ -210,6 +210,7 @@ class _EventPoller:
 
     def __init__(self, sig_events):
         self.sig_events = sig_events
+        self.__worker = None
 
     def start(self, proactor):
         self._logger.debug("Starting (proactor: %s)...", proactor)
@@ -218,4 +219,6 @@ class _EventPoller:
 
     def stop(self):
         self._logger.debug("Stopping worker thread...")
-        self.__worker.stop()
+        if self.__worker is not None:
+            self.__worker.stop()
+            self.__worker = None

--- a/src/qasync/_windows.py
+++ b/src/qasync/_windows.py
@@ -38,6 +38,9 @@ class _ProactorEventLoop(asyncio.ProactorEventLoop):
         self.__event_signal.connect(self._process_events)
         self.__event_poller = _EventPoller(self.__event_signal)
 
+    def get_proactor_event_poller(self):
+        return self.__event_poller
+
     def _process_events(self, events):
         """Process events from proactor."""
         for f, callback, transferred, key, ov in events:

--- a/tests/test_qeventloop.py
+++ b/tests/test_qeventloop.py
@@ -18,34 +18,7 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import pytest
 
 import qasync
-
 from qasync import QtCore
-import traceback, logging
-
-_orig_setParent = QtCore.QObject.setParent
-
-
-def _dbg_setParent(self, parent):
-    if parent is not None:
-        try:
-            same = parent.thread() is self.thread()
-        except Exception:
-            same = False
-        if not same:
-            logging.error(
-                "QObject.setParent across threads: obj=%r obj.thread=%r parent=%r parent.thread=%r",
-                self,
-                self.thread(),
-                parent,
-                getattr(parent, "thread", lambda: None)(),
-            )
-            traceback.print_stack()  # prints Python stack where setParent was called
-            # Optionally raise so test fails and you can inspect the stack in the debugger:
-            # raise RuntimeError("setParent called from wrong thread")
-    return _orig_setParent(self, parent)
-
-
-QtCore.QObject.setParent = _dbg_setParent
 
 
 @pytest.fixture


### PR DESCRIPTION
Runnint the unittests with PySide is sometimes prone to crashing (see #154)
This PR fixes the issues by making lifetime management more robust.

- Timer and signaller objects are parented to the `app`, for lifetime management.
- QSocketNotifiers are also parented to the `app` for lifetime management
- QEventLoop.close() is made more robust:
  - The `EventPoller` is stopped.
  - objects get a `.deleteLater()` for tidyness in case the __app lives on
  - disconnect() calls are guarded against errors due to different bindings.