### PR TITLE
Add Python 3.14 tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows, macos-x86_64, macos-arm64]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         qt-version: ["pyside2", "pyside6", "pyqt5", "pyqt6"]
         include:
           - os: ubuntu
@@ -42,6 +42,8 @@ jobs:
           - python-version: "3.12"
             qt-version: pyside2
           - python-version: "3.13"
+            qt-version: pyside2
+          - python-version: "3.14"
             qt-version: pyside2
           # pyside6 and pyqt6 require python >=3.9
           - python-version: "3.8"

--- a/src/qasync/__init__.py
+++ b/src/qasync/__init__.py
@@ -515,7 +515,7 @@ class _QEventLoop:
 
     def call_later(self, delay, callback, *args, context=None):
         """Register callback to be invoked after a certain delay."""
-        if asyncio.iscoroutinefunction(callback):
+        if inspect.iscoroutinefunction(callback):
             raise TypeError("coroutines cannot be used with call_later")
         if not callable(callback):
             raise TypeError(


### PR DESCRIPTION
Python 3.14 released a week ago officially, and we already have all the infrastructure to work with it properly AFAICT.